### PR TITLE
chore(ci): use config:js-lib preset from renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,3 @@
 {
-  "extends": [
-    "config:base",
-    ":automergeMinor"
-  ]
+  "extends": ["config:js-lib", ":automergeMinor"]
 }


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Changes renovate behavior to only pin dev dependencies

- **What is the current behavior?** (You can also link to an open issue here)
Pins all dependencies, which is not appropriate for a js library

- **What is the new behavior (if this is a feature change)?**
Only pins dev dependencies

- **Other information**:
https://docs.renovatebot.com/presets-config/#configjs-lib
