### PR TITLE
chore(ci): require conventional commit message on PRs

### DIFF
--- a/.github/workflows/lint_cr.yml
+++ b/.github/workflows/lint_cr.yml
@@ -1,0 +1,20 @@
+name: "Lint PR"
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+
+jobs:
+  main:
+    runs-on: ubuntu-latest
+    steps:
+      # Please look up the latest version from
+      # https://github.com/amannn/action-semantic-pull-request/releases
+      - uses: amannn/action-semantic-pull-request@v3.4.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          validateSingleCommit: true


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
New CI check

- **What is the current behavior?** (You can also link to an open issue here)
#4 wants this.

- **What is the new behavior (if this is a feature change)?**
PRs will be invalid if they don't follow conventional commit naming.

- **Other information**:
https://github.com/marketplace/actions/semantic-pull-request